### PR TITLE
Fixes for fire perimeter

### DIFF
--- a/io/namelist_mod.F90
+++ b/io/namelist_mod.F90
@@ -58,7 +58,7 @@
       integer :: fire_upwinding_reinit = 4    ! "numerical scheme (space) for reinitialization PDE: 1=WENO3, 2=WENO5, 3=hybrid WENO3-ENO1, 4=hybrid WENO5-ENO1"
       integer :: fire_lsm_band_ngp = 4        ! "number of grid points around lfn=0 that WENO5/3 is used (ENO1 elsewhere),
                                               ! for fire_upwinding_reinit=4,5 and fire_upwinding=8,9 options"
-      real :: reinit_pseudot_coef = 0.01      ! Coefficient for the pseudo time
+      real :: reinit_pseudot_coef = 0.0001    ! Coefficient for the pseudo time
 
       integer :: fast_dist_reinit_opt = 0     ! Fast distance reinitialization method (or eikonal solver): 0) None, 1) FSM
       integer :: fast_dist_reinit_freq = 600  ! Number of time steps to perform a reinit with fast distance reinit method

--- a/physics/level_set_mod.F90
+++ b/physics/level_set_mod.F90
@@ -1974,22 +1974,31 @@
 
     pure function Select_eno (diff_lx, diff_rx) result (return_value)
 
-      ! 1st order ENO scheme: choose the smaller magnitude derivative
-      ! Both positive: pick smaller
-      ! Both negative: pick larger (less negative)
-      ! Mixed signs: zero (derivative crosses zero)
+      ! 1st order ENO scheme
 
       implicit none
 
-      real, intent(in) :: diff_lx, diff_rx
+      real, intent (in):: diff_lx, diff_rx
       real :: return_value
 
+      real :: diff2x
 
-      if (diff_lx * diff_rx > 0.0) then
-        return_value = sign(1.0, diff_lx) * min(abs(diff_lx), abs(diff_rx))
+
+      if (.not. diff_lx > 0.0 .and. .not. diff_rx > 0.0) then
+        diff2x = diff_rx
+      else if (.not. diff_lx < 0.0 .and. .not. diff_rx < 0.0) then
+        diff2x = diff_lx
+      else if (.not. diff_lx < 0.0 .and. .not. diff_rx > 0.0) then
+        if (.not. abs (diff_rx) < abs(diff_lx)) then
+          diff2x = diff_rx
+        else
+          diff2x = diff_lx
+        end if
       else
-        return_value = 0.0
+        diff2x = 0.0
       end if
+
+      return_value = diff2x
 
     end function Select_eno
 


### PR DESCRIPTION
Testing the most recent version of the UFS fire behavior code has shown some unexpected results. The default case in the SRW Application prior to the latest changes (https://github.com/ufs-community/ufs-srweather-app/pull/1376) showed reasonable results. However, after those changes, the fire perimeter after 6 hours showed some anomalies:

<img width="400" alt="ncview fire_area_081400" src="https://github.com/user-attachments/assets/7c47c0d5-dcd7-4cff-af64-1bc45481b8e1" />

After 16 hours the simulation was completely unrealistic:

<img width="400" alt="ncview fire_area_081410" src="https://github.com/user-attachments/assets/22e33f03-e46f-439a-a406-a063b31a833d" />

And the simulation stopped after ~18 hours due to the fire reaching the boundary.

The fixes are as follows:

 - Return the pseudo time coefficient (`reinit_pseudot_coef`) to its previous default value of 0.0001. This resulted in an improvement but still anomalous results: 
<img width="198" height="198" alt="image" src="https://github.com/user-attachments/assets/b708c008-fc82-4bcb-96c1-9f36e4a7e855" />

 - Restore the 1st order ENO scheme to its previous version

After these changes, the results at long lead times again look realistic:

<img width="187" height="186" alt="image" src="https://github.com/user-attachments/assets/4aac2f07-6131-4e9e-8854-6242a32b2512" />




